### PR TITLE
Add Tux Paint stamps to paint

### DIFF
--- a/Area.py
+++ b/Area.py
@@ -387,12 +387,12 @@ class Area(Gtk.DrawingArea):
         rainbow and eraser
         """
         if self.tool['name'] in ['pencil', 'eraser', 'brush', 'rainbow',
-                                 'stamp']:
+                                 'stamp', 'load-stamp']:
             if not self.drawing:
                 context.set_source_rgba(*self.tool['cairo_stroke_color'])
                 context.set_line_width(1)
                 # draw stamp border in widget.window
-                if self.tool['name'] == 'stamp':
+                if self.tool['name'] in ('stamp', 'load-stamp'):
                     wr, hr = self.stamp_dimentions
                     context.rectangle(self.x_cursor - wr / 2,
                                       self.y_cursor - hr / 2, wr, hr)
@@ -495,7 +495,7 @@ class Area(Gtk.DrawingArea):
                 self.d.brush(self, coords, self.last)
                 self.last = coords
                 self.drawing = True
-            elif self.tool['name'] == 'stamp':
+            elif self.tool['name'] in ('stamp', 'load-stamp'):
                 self.last = []
                 self.d.stamp(self, coords, self.last)
                 self.last = coords
@@ -563,7 +563,7 @@ class Area(Gtk.DrawingArea):
             if point[1] > max_y:
                 max_y = point[1]
         # add the tool size
-        if self.tool['name'] == 'stamp':
+        if self.tool['name'] in ('stamp', 'load-stamp'):
             wr, hr = self.stamp_dimentions
         elif self.tool['name'] == 'freeform':
             wr = hr = 20
@@ -631,7 +631,7 @@ class Area(Gtk.DrawingArea):
                 self.d.brush(self, coords, self.last)
                 self.last = coords
 
-            elif self.tool['name'] == 'stamp':
+            elif self.tool['name'] in ('stamp', 'load-stamp'):
                 self.d.stamp(self, coords, self.last,
                              self.tool['stamp size'])
                 self.last = coords
@@ -694,7 +694,7 @@ class Area(Gtk.DrawingArea):
                     self.d.heart(self, coords, True, self.tool['fill'])
         else:
             if self.tool['name'] in ['brush', 'eraser', 'rainbow', 'pencil',
-                                     'stamp']:
+                                     'stamp', 'load-stamp']:
                 # define area to update (only to show the brush shape)
                 last_coords = (self.last_x_cursor, self.last_y_cursor)
                 area = self.calculate_damaged_area([last_coords, coords])
@@ -801,7 +801,7 @@ class Area(Gtk.DrawingArea):
                     self.getout()
 
         if self.tool['name'] in ['brush', 'eraser', 'rainbow', 'pencil',
-                                 'stamp']:
+                                 'stamp', 'load-stamp']:
             self.last = []
             self.d.finish_trace(self)
             self.drawing = False
@@ -936,7 +936,7 @@ class Area(Gtk.DrawingArea):
 
     def mouseleave(self, widget, event):
         if self.tool['name'] in ['pencil', 'eraser', 'brush', 'rainbow',
-                                 'stamp']:
+                                 'stamp', 'load-stamp']:
             self.drawing = True
             size = self.tool['line size']
             widget.queue_draw_area(self.x_cursor - size, self.y_cursor - size,
@@ -944,21 +944,29 @@ class Area(Gtk.DrawingArea):
 
     def mouseenter(self, widget, event):
         if self.tool['name'] in ['pencil', 'eraser', 'brush', 'rainbow',
-                                 'stamp']:
+                                 'stamp', 'load-stamp']:
             self.drawing = False
             size = self.tool['line size']
             widget.queue_draw_area(self.x_cursor - size, self.y_cursor - size,
                                    size * 2, size * 2)
 
-    def setup_stamp(self):
+    def setup_stamp(self, stamp=None):
         """Prepare for stamping from the selected area.
 
             @param  self -- the Area object (GtkDrawingArea)
         """
-        if self.is_selected():
+        if self.is_selected() or stamp:
             # Change stamp, get it from selection:
             pixbuf_data = StringIO.StringIO()
-            self.get_selection().write_to_png(pixbuf_data)
+            if stamp:
+                fd = open(stamp, 'r')
+                pixbuf_data.write(fd.read())
+                fd.close()
+            elif self.is_selected() and not stamp:
+                self.get_selection().write_to_png(pixbuf_data)
+            else:
+                return
+
             pxb_loader = GdkPixbuf.PixbufLoader.new_with_type('png')
             pxb_loader.write(pixbuf_data.getvalue())
 
@@ -1676,11 +1684,15 @@ class Area(Gtk.DrawingArea):
             elif self.tool['name'] == 'marquee-rectangular':
                 cursor = Gdk.Cursor.new(Gdk.CursorType.CROSS)
             else:
-                filename = os.path.join('images', self.tool['name'] + '.png')
+                name = self.tool['name']
+                if name == 'load-stamp':
+                    name = 'stamp'
+
+                filename = os.path.join('images', name + '.png')
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file(filename)
 
                 # Decide which is the cursor hot spot offset:
-                if self.tool['name'] == 'stamp':
+                if self.tool['name'] in ('stamp', 'load-stamp'):
                     hotspot_x, hotspot_y = 20, 38  # horizontal
                                                     # center and
                                                     # bottom
@@ -1787,7 +1799,7 @@ class Area(Gtk.DrawingArea):
             self.configure_line(size)
             # TODO: clip
             self.queue_draw()
-        if self.tool['name'] == 'stamp':
+        if self.tool['name'] in ('stamp', 'load-stamp'):
             self.resize_stamp(self.stamp_size + delta)
             # TODO: clip
             self.queue_draw()

--- a/dialogs.py
+++ b/dialogs.py
@@ -1,0 +1,169 @@
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gettext import gettext as _
+import os
+import random
+import glob
+
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import GdkPixbuf
+
+from sugar3.graphics import style
+from sugar3.graphics.toolbutton import ToolButton
+from sugar3.graphics.icon import Icon
+
+STORE = None
+
+
+class _DialogWindow(Gtk.Window):
+
+    # A base class for a modal dialog window.
+
+    def __init__(self, icon_name, title):
+        super(_DialogWindow, self).__init__()
+
+        self.set_border_width(style.LINE_WIDTH)
+        width = Gdk.Screen.width() - style.GRID_CELL_SIZE * 2
+        height = Gdk.Screen.height() - style.GRID_CELL_SIZE * 2
+        self.set_size_request(width, height)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_decorated(False)
+        self.set_resizable(False)
+        self.set_modal(True)
+
+        vbox = Gtk.VBox()
+        self.add(vbox)
+
+        toolbar = _DialogToolbar(icon_name, title)
+        toolbar.connect('stop-clicked', self._stop_clicked_cb)
+        vbox.pack_start(toolbar, False, False, 0)
+
+        self.content_vbox = Gtk.VBox()
+        self.content_vbox.set_border_width(style.DEFAULT_SPACING)
+        vbox.add(self.content_vbox)
+
+        self.connect('realize', self._realize_cb)
+
+    def _stop_clicked_cb(self, source):
+        self.destroy()
+
+    def _realize_cb(self, source):
+        self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+        self.get_window().set_accept_focus(True)
+
+
+class _DialogToolbar(Gtk.Toolbar):
+
+    # Displays a dialog window's toolbar, with title, icon, and close box.
+
+    __gsignals__ = {
+        'stop-clicked': (GObject.SignalFlags.RUN_LAST, None, ()),
+    }
+
+    def __init__(self, icon_name, title):
+        super(_DialogToolbar, self).__init__()
+
+        if icon_name is not None:
+            icon = Icon()
+            icon.set_from_icon_name(icon_name, Gtk.IconSize.LARGE_TOOLBAR)
+            self._add_widget(icon)
+
+        self._add_separator()
+
+        label = Gtk.Label(label=title)
+        self._add_widget(label)
+
+        self._add_separator(expand=True)
+
+        stop = ToolButton(icon_name='dialog-cancel')
+        stop.set_tooltip(_('Done'))
+        stop.connect('clicked', self._stop_clicked_cb)
+        self.add(stop)
+
+    def _add_separator(self, expand=False):
+        separator = Gtk.SeparatorToolItem()
+        separator.set_expand(expand)
+        separator.set_draw(False)
+        self.add(separator)
+
+    def _add_widget(self, widget):
+        tool_item = Gtk.ToolItem()
+        tool_item.add(widget)
+        self.add(tool_item)
+
+    def _stop_clicked_cb(self, button):
+        self.emit('stop-clicked')
+
+
+class TuxStampDialog(_DialogWindow):
+    __gsignals__ = {
+        'stamp-selected': (
+            GObject.SIGNAL_RUN_FIRST,
+            GObject.TYPE_NONE,
+            (GObject.TYPE_STRING,
+             ))}
+
+    def __init__(self):
+        super(TuxStampDialog, self).__init__('tool-stamp', _('Select stamp'))
+
+        global STORE
+        if not STORE:
+            STORE = self._create_model()
+
+        self._iconview = Gtk.IconView()
+        self._iconview.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        self._iconview.set_model(STORE)
+        self._iconview.set_pixbuf_column(0)
+        self._iconview.connect('selection-changed', self._stamp_changed)
+
+        scrollwin = Gtk.ScrolledWindow()
+        scrollwin.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.content_vbox.pack_start(scrollwin, True, True, 0)
+        scrollwin.add(self._iconview)
+
+        scrollwin.show_all()
+
+    def _stamp_changed(self, widget):
+        items = widget.get_selected_items()
+        if not items:
+            return
+
+        iter_ = STORE.get_iter(items[0])
+        filepath = STORE.get(iter_, 1)[0]
+        self.emit('stamp-selected', filepath)
+        self.destroy()
+
+    def _create_model(self):
+        tuxstamps = '/usr/share/tuxpaint/stamps'
+        categories = []
+        dirs = os.listdir(tuxstamps)
+        for d in dirs:
+            d = os.path.join(tuxstamps, d)
+            if os.path.isdir(d):
+                categories.append(d)
+
+        store = Gtk.ListStore(GdkPixbuf.Pixbuf, str)
+        for cat in categories:
+            patron = os.path.join(tuxstamps, cat)
+            for x in range(5):
+                patron = patron + "/*"
+                files = glob.iglob(patron + '.png')
+                for f in files:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(f, 50, 50)
+                    store.append([pixbuf, f])
+        return store

--- a/toolbox.py
+++ b/toolbox.py
@@ -61,6 +61,8 @@ Walter Bender                       (walter@laptop.org)
 
 """
 
+import os
+
 from gettext import gettext as _
 
 from gi.repository import Gtk
@@ -93,6 +95,8 @@ from sugar3.activity.widgets import StopButton
 
 from fontcombobox import FontComboBox
 from fontcombobox import FontSize
+
+from dialogs import TuxStampDialog
 
 
 def add_menu(icon_name, tooltip, tool_name, button, activate_cb):
@@ -379,6 +383,13 @@ class ToolsToolbarBuilder():
 
         is_selected = self._activity.area.is_selected()
         self._tool_stamp.set_sensitive(is_selected)
+
+        # tuxpaint-stamps install dir.
+        tuxstamps = '/usr/share/tuxpaint/stamps'
+        if os.path.exists(tuxstamps):
+            add_menu('tool-stamp', _('Load stamp'), 'load-stamp',
+                     self._tool_brush, self.set_tool)
+
         self._activity.area.connect('undo', self._on_signal_undo_cb)
         self._activity.area.connect('redo', self._on_signal_redo_cb)
         self._activity.area.connect('select', self._on_signal_select_cb)
@@ -407,6 +418,7 @@ class ToolsToolbarBuilder():
                           necessary in case this method is used in a connect()
             @param tool_name --The name of the selected tool
         """
+
         if widget != self._tool_brush:
             self._tool_brush.set_icon_name(widget.icon_name)
             self._stroke_color.set_selected_tool(tool_name)
@@ -418,6 +430,12 @@ class ToolsToolbarBuilder():
             self._stroke_color.color_button.stop_stamping()
         if tool_name != self._TOOL_MARQUEE_RECT_NAME:
             self._activity.area.end_selection()
+
+        if tool_name == 'load-stamp':
+            dialog = TuxStampDialog()
+            dialog.set_transient_for(self._activity)
+            dialog.connect('stamp-selected', self._load_stamp)
+            dialog.show_all()
 
         self._stroke_color.update_stamping()
         self.properties['name'] = tool_name
@@ -450,6 +468,10 @@ class ToolsToolbarBuilder():
         sensitive = self._activity.area.is_selected() or \
             self.properties['name'] == 'stamp'
         self._tool_stamp.set_sensitive(sensitive)
+
+    def _load_stamp(self, widget, filepath):
+        resized_stamp = self._activity.area.setup_stamp(stamp=filepath)
+        self._stroke_color.color_button.set_resized_stamp(resized_stamp)
 
 
 class ButtonFillColor(ColorToolButton):

--- a/widgets.py
+++ b/widgets.py
@@ -312,7 +312,7 @@ class ButtonStrokeColor(Gtk.ToolItem):
             show_colors = True
             show_controls = (self.size_label, self.size_scale, self.shape_box,
                              self.alpha_label, self.alpha_scale)
-        elif tool_name == 'stamp':
+        elif tool_name in ('stamp', 'load-stamp'):
             show_controls = (self.size_label, self.size_scale)
             title = _('Stamp properties')
         elif tool_name == 'eraser':


### PR DESCRIPTION
This patch add tuxpaint stamps to paint activity,
if the stamps are installed (tuxpaint-stamps package)
the option in the menu will appear.

This will show a dialog with all tuxpaint stamps, click one
and it will set at stamp in paint.
