### PR TITLE
Defend against Gtk3 cursor new_from_name bug

### DIFF
--- a/Area.py
+++ b/Area.py
@@ -1772,7 +1772,7 @@ class Area(Gtk.DrawingArea):
 
                 cursor = Gdk.Cursor.new_from_pixbuf(display, pixbuf,
                                                     hotspot_x, hotspot_y)
-        except GObject.GError:
+        except GObject.GError, TypeError:
             cursor = None
         if self.get_window() is not None:
             self.get_window().set_cursor(cursor)


### PR DESCRIPTION
On Ubuntu 16.10 and later, Gdk.Cursor raises a TypeError instead of returning None as documented.

Fixes
```
    File "/usr/share/sugar/activities/Paint.activity/Area.py", line 1754, in
    set_tool_cursor
        cursor = Gdk.Cursor.new_from_name(display, name)
    TypeError: constructor returned NULL
```
Documentation reference:

 * [Gdk.Cursor.new_from_name](https://lazka.github.io/pgi-docs/Gdk-3.0/classes/Cursor.html#Gdk.Cursor.new_from_name)

----

This patch has been in my repository for some time, looks like SoaS also affected;
cc @walterbender re [your repost](http://lists.sugarlabs.org/archive/sugar-devel/2017-February/053790.html) of @nullr0ute reply to same problem seen by [Raul Benitez](http://lists.sugarlabs.org/archive/soas/2017-February/002881.html) ... in my tests it was caused by upgrading Gtk+, so it is likely a Gtk+ problem at root.  Either documentation or implementation at fault.