### PR TITLE
Text tool fixes

### DIFF
--- a/Area.py
+++ b/Area.py
@@ -91,7 +91,7 @@ FALLBACK_FILL = True
 try:
     from fill import fill
     FALLBACK_FILL = False
-    logging.error('Found fill binaries.')
+    logging.debug('Found fill binaries.')
 except:
     logging.error('No valid fill binaries. Using slower python code')
     pass
@@ -131,7 +131,7 @@ if _HAS_GST:
 def _get_screen_dpi():
     xft_dpi = Gtk.Settings.get_default().get_property('gtk-xft-dpi')
     dpi = float(xft_dpi / 1024)
-    logging.error('Setting dpi to: %f', dpi)
+    logging.debug('Setting dpi to: %f', dpi)
     return dpi
 
 bundle_path = activity.get_bundle_path()

--- a/Area.py
+++ b/Area.py
@@ -1772,7 +1772,7 @@ class Area(Gtk.DrawingArea):
 
                 cursor = Gdk.Cursor.new_from_pixbuf(display, pixbuf,
                                                     hotspot_x, hotspot_y)
-        except GObject.GError, TypeError:
+        except (GObject.GError, TypeError):
             cursor = None
         if self.get_window() is not None:
             self.get_window().set_cursor(cursor)

--- a/Desenho.py
+++ b/Desenho.py
@@ -682,7 +682,6 @@ class Desenho:
             GObject.idle_add(self._finalize_text, widget, textview)
 
     def _finalize_text(self, widget, textview):
-        buf = textview.get_buffer()
         window = textview.get_window(Gtk.TextWindowType.TEXT)
         ctx = widget.drawing_ctx
         tv_alloc = textview.get_allocation()
@@ -692,10 +691,7 @@ class Desenho:
         widget.activity.textview.hide()
         widget.drawing_canvas.flush()
 
-        try:
-            widget.activity.textview.set_text('')
-        except AttributeError:
-            buf.set_text('')
+        textview.get_buffer().set_text('')
 
         widget.enable_undo()
         widget.queue_draw()

--- a/OficinaActivity.py
+++ b/OficinaActivity.py
@@ -286,6 +286,7 @@ class OficinaActivity(activity.Activity):
                 text_buf = self.textview.get_buffer()
                 end_text_iter = text_buf.get_end_iter()
                 text_buf.select_range(end_text_iter, end_text_iter)
+        return False
 
     def __textview_mouse_move_cb(self, widget, event):
         x = event.x
@@ -295,3 +296,4 @@ class OficinaActivity(activity.Activity):
             dy = y - self._initial_textview_touch_y
             tv_alloc = self.textview.get_allocation()
             self.move_textview(tv_alloc.x + dx, tv_alloc.y + dy)
+        return False

--- a/OficinaActivity.py
+++ b/OficinaActivity.py
@@ -98,7 +98,6 @@ class OficinaActivity(activity.Activity):
         self.fixed = Gtk.Fixed()
         self._width = Gdk.Screen.width()
         self._height = Gdk.Screen.height()
-        self.fixed.show()
         self.fixed.modify_bg(Gtk.StateType.NORMAL,
                              style.COLOR_WHITE.get_gdk_color())
 
@@ -114,13 +113,13 @@ class OficinaActivity(activity.Activity):
         self.textview.connect('event', self.__textview_event_cb)
         self.textview.connect("motion_notify_event",
                               self.__textview_mouse_move_cb)
+        self.textview.hide()  # will be shown when text tool is used
 
-        self.fixed.put(self.textview, 0, 0)
-
-        # These attributes are used in other classes, so they should be public
         self.area = Area(self)
         self.area.show()
         self.fixed.put(self.area, 0, 0)
+        self.fixed.put(self.textview, 0, 0)
+        self.fixed.show()
 
         self._sw = Gtk.ScrolledWindow()
         self._sw.set_kinetic_scrolling(False)

--- a/OficinaActivity.py
+++ b/OficinaActivity.py
@@ -261,7 +261,7 @@ class OficinaActivity(activity.Activity):
             self.area.tool = json.loads(self.metadata['state'])
             logging.debug('self.area.tool %s', self.area.tool)
         except Exception as e:
-            logging.error("exception %s", e)
+            logging.debug("exception %s", e)
 
     def __textview_event_cb(self, widget, event):
         if event.type in (Gdk.EventType.TOUCH_BEGIN,

--- a/OficinaActivity.py
+++ b/OficinaActivity.py
@@ -61,6 +61,11 @@ Walter Bender                       (walter@laptop.org)
 
 """
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gst', '1.0')
+gi.require_version('PangoCairo', '1.0')
+
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject

--- a/fill/__init__.py
+++ b/fill/__init__.py
@@ -11,11 +11,11 @@ for i in os.listdir(_root_path):
         sys.path = _sys_path + [os.path.join('.', path)]
         try:
             from _fill import *
-            logging.error('use %s blobs' % path)
+            logging.debug('use %s blobs' % path)
             _sys_path = None
             break
         except Exception, e:
-            logging.error('skip %s blobs: %s' % (path, e))
+            logging.debug('skip %s blobs: %s' % (path, e))
 
 if _sys_path:
     raise('cannot find proper binary blobs')


### PR DESCRIPTION
* fix for a "text functionality does not work, the letters are not shown on the screen when typing from the keyboard", reported by [Raul Benitez](http://lists.sugarlabs.org/archive/soas/2017-February/002887.html) on the SoaS mailing list; there is no documentation for the stacking order of widgets in a Gtk.Fixed, but evidently the last one added is the most visible.
* fix for a mistake in previous PR #18,
* remove several normal log messages from logs.

Note that a floating text insertion will be abandoned if a brush or pencil tool is used while the cursor is flashing.  Workaround is to complete the floating text insertion with a click away from the text.
