### PR TITLE
Explicitly call map_cp on start

### DIFF
--- a/OficinaActivity.py
+++ b/OficinaActivity.py
@@ -153,6 +153,7 @@ class OficinaActivity(activity.Activity):
                                                   size_allocate_cb)
 
         self._setup_handle = self.connect('map', map_cp)
+        map_cp(self)
 
         # Handle screen rotation
         Gdk.Screen.get_default().connect('size-changed', self._configure_cb)


### PR DESCRIPTION
Without this, the drawing area is invisible.