### PR TITLE
Fit big images to screen

### DIFF
--- a/Area.py
+++ b/Area.py
@@ -1668,10 +1668,29 @@ class Area(Gtk.DrawingArea):
 
         logging.debug('image size %d x %d', width, height)
 
+        c_width = self.get_allocation().width
+        c_height = self.get_allocation().height
+        scale = None
+
+        # Checking if image exceed the editing area
+        if width > c_width or height > c_height:
+            # Calculate scaling factor
+            scale_x = c_width / width
+            scale_y = c_height / height
+            scale = min(scale_x, scale_y)
+
+            # Calculate new width and height
+            width = int(width * scale)
+            height = int(height * scale)
+
         # load in the selection surface
         self.selection_surface = cairo.ImageSurface(
             cairo.FORMAT_ARGB32, width, height)
         selection_ctx = cairo.Context(self.selection_surface)
+
+        # Scale the pixbuf to fit the new dimensions
+        if scale is not None:
+            selection_ctx.scale(scale, scale)
         self._pixbuf_to_context(pixbuf, selection_ctx)
 
         # show in the temp context too


### PR DESCRIPTION
image insert option used to load images with full resolution, which causes the image to extend beyond the editing area, resulting in unwanted cropping of the loaded image

This commit can determine the size difference between loaded image and editing area, and change loaded image size accordingly to fit editing area. 
It can fix #38