### PR TITLE
Fix Fill Color button responsiveness for shape tools

### DIFF
--- a/toolbox.py
+++ b/toolbox.py
@@ -163,6 +163,17 @@ class DrawToolbarBox(ToolbarBox):
         self.shapes_builder = ShapesToolbarBuilder(self._activity,
                                                    self.shapes_button,
                                                    self._fill_color_button)
+
+        def on_tool_changed(tool_name):
+            if tool_name in ('ellipse', 'rectangle', 'line', 'freeform', 'heart',
+                            'parallelogram', 'arrow', 'star', 'trapezoid',
+                            'triangle', 'polygon_regular'):
+                self._fill_color_button.set_sensitive(True)
+            else:
+                self._fill_color_button.set_sensitive(False)
+
+        self.tools_builder.connect("tool-changed", on_tool_changed)
+        self.shapes_builder.connect("tool-changed", on_tool_changed)
         self.initialize_brush_shape_tools()
 
         self.toolbar.insert(item_fill_color, -1)


### PR DESCRIPTION
The Fill Color button was unresponsive when shape tools were selected in the toolbar. Now the button is dynamically enabled only for shape tools (ellipse, rectangle, line, freeform, heart, parallelogram, arrow, star, trapezoid, triangle, polygon_regular) and disabled for other tools.
6
This ensures predictable behavior when switching between brush, eraser, and shape tools, improving the usability of the Paint activity.

Fixes #46