### PR TITLE
Fix activity crash which occurs when cursor icons with the given name…

### DIFF
--- a/Area.py
+++ b/Area.py
@@ -926,7 +926,12 @@ class Area(Gtk.DrawingArea):
             logging.debug('Already filled')
             # reset the cursor
             display = Gdk.Display.get_default()
-            cursor = Gdk.Cursor.new_from_name(display, 'paint-bucket')
+            try:
+                cursor = Gdk.Cursor.new_from_name(display, 'paint-bucket')
+            except:
+                cursor=None
+            if cursor is None:
+                cursor = Gdk.Cursor.new_from_name(display, 'crosshair')
             self.get_window().set_cursor(cursor)
             return
 
@@ -974,7 +979,12 @@ class Area(Gtk.DrawingArea):
         self.enable_undo()
 
         display = Gdk.Display.get_default()
-        cursor = Gdk.Cursor.new_from_name(display, 'paint-bucket')
+        try:
+            cursor = Gdk.Cursor.new_from_name(display, 'paint-bucket')
+        except:
+            cursor=None
+        if cursor is None:
+                cursor = Gdk.Cursor.new_from_name(display, 'crosshair')
         if self._sounds_enabled:
             self.play_tool_sound()
         self.get_window().set_cursor(cursor)


### PR DESCRIPTION
This PR fixes a crash occurring on modern Linux distributions (like Ubuntu 24.04) where the activity cannot find the 'paint-bucket'  icon in the system cursor theme.

The call Gdk.Cursor.new_from_name(display, 'paint-bucket') returns NULL when the icon is missing. This triggers a TypeError: constructor returned NULL and immediately terminates the activity.

Wrapped the cursor creation in a try...except block. If the themed icon fails to load, the activity now falls back to the standard crosshair cursor.

Testing:
->Activity starts successfully.
->Selecting the Fill (bucket) tool no longer crashes the app.
->Verified that the cursor appears as a plus sign (+) when the theme icon is missing.

fixes sugarlabs/sugar-artwork#127 